### PR TITLE
feat: Add .NET version check and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This script is used to process and send MARC (`.mrc`) files, created by the Simp
 
 ## Prerequisites
 
+*   **.NET Framework 4.5 or newer**: This script requires the .NET Framework version 4.5 or higher to be installed on the system.
 *   **SimplyReports MARC Export**: The `.mrc` files must be generated using the **CollectionHQ MARC export profile** in SimplyReports.
 *   **WinSCP**: This script requires the `WinSCPnet.dll` assembly to be present in the same directory as the script. This is used for transferring files via FTP.
 

--- a/send-mrc.ps1
+++ b/send-mrc.ps1
@@ -3,6 +3,26 @@ param (
     [switch]$ForceRun
 )
 
+# --- Prerequisite Check: .NET Framework Version ---
+try {
+    # WinSCPnet.dll requires .NET Framework 4.5 or newer.
+    # .NET 4.5 release number is 378389.
+    $requiredNetVersion = 378389
+    $netVersion = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" -ErrorAction Stop | Select-Object -ExpandProperty Release
+
+    if ($netVersion -lt $requiredNetVersion) {
+        Write-Output "FATAL: This script requires .NET Framework 4.5 or newer."
+        Write-Output "Please upgrade your .NET Framework version to run this script."
+        exit 1
+    }
+}
+catch {
+    Write-Output "FATAL: Could not determine .NET Framework version."
+    Write-Output "This may be because .NET Framework 4.5 or newer is not installed."
+    Write-Output "Please ensure .NET Framework 4.5 or newer is installed and try again."
+    exit 1
+}
+
 # Get the script's path dynamically
 $scriptpath = $PSScriptRoot
 


### PR DESCRIPTION
Adds a prerequisite check to ensure that .NET Framework 4.5 or newer is installed before the script attempts to use the WinSCPnet.dll assembly. This prevents the script from failing with a 'Method not found' error on systems with older .NET versions.

- Added a .NET Framework version check to `send-mrc.ps1`.
- Updated `README.md` to include the .NET 4.5 prerequisite.